### PR TITLE
Increase the light intensity and modify skills (according to the offi…

### DIFF
--- a/Client/MirGraphics/DXManager.cs
+++ b/Client/MirGraphics/DXManager.cs
@@ -191,10 +191,10 @@ namespace Client.MirGraphics
                             using (PathGradientBrush brush = new PathGradientBrush(path))
                             {
                                 Color[] blendColours = { Color.White,
-                                                     Color.FromArgb(255,150,150,150),
-                                                     Color.FromArgb(255,60,60,60),
-                                                     Color.FromArgb(255,30,30,30),
-                                                     Color.FromArgb(255,10,10,10),
+                                                     Color.FromArgb(255,210,210,210),
+                                                     Color.FromArgb(255,160,160,160),
+                                                     Color.FromArgb(255,70,70,70),
+                                                     Color.FromArgb(255,40,40,40),
                                                      Color.FromArgb(0,0,0,0)};
 
                                 float[] radiusPositions = { 0f, .20f, .40f, .60f, .80f, 1.0f };

--- a/Client/MirObjects/UserObject.cs
+++ b/Client/MirObjects/UserObject.cs
@@ -580,6 +580,8 @@ namespace Client.MirObjects
 
         private void RefreshSkills()
         {
+            int[] spiritSwordLvPlus = { 0, 3, 5, 8 };
+            int[] slayingLvPlus = {5, 6, 7, 8};
             for (int i = 0; i < Magics.Count; i++)
             {
                 ClientMagic magic = Magics[i];
@@ -587,14 +589,17 @@ namespace Client.MirObjects
                 {
                     case Spell.Fencing:
                         Stats[Stat.Accuracy] += magic.Level * 3;
-                        Stats[Stat.MaxAC] += (magic.Level + 1) * 3;
+                        //Stats[Stat.MaxAC] += (magic.Level + 1) * 3;
                         break;
-                    case Spell.FatalSword:
+                    case Spell.Slaying:
+                    // case Spell.FatalSword:
                         Stats[Stat.Accuracy] += magic.Level;
+                        Stats[Stat.MaxDC] += slayingLvPlus[magic.Level];
                         break;
                     case Spell.SpiritSword:
-                        Stats[Stat.Accuracy] += magic.Level;
-                        Stats[Stat.MaxDC] += (int)(Stats[Stat.MaxSC] * (magic.Level + 1) * 0.1F);
+                        Stats[Stat.Accuracy] += spiritSwordLvPlus[magic.Level];
+                        // Stats[Stat.Accuracy] += magic.Level;
+                        // Stats[Stat.MaxDC] += (int)(Stats[Stat.MaxSC] * (magic.Level + 1) * 0.1F);
                         break;
                 }
             }

--- a/Server/MirEnvir/Map.cs
+++ b/Server/MirEnvir/Map.cs
@@ -1834,72 +1834,63 @@ namespace Server.MirEnvir
                     value = (int)data[2];
                     location = (Point)data[3];
 
-                    for (int y = location.Y - 3; y <= location.Y + 3; y++)
+                    int posX = location.X;
+                    int posY = location.Y;
+                    
+                    cell = GetCell(posX, posY);
+
+                    if (!cell.Valid || cell.Objects == null) return;
+
+                    for (int i = 0; i < cell.Objects.Count; i++)
                     {
-                        if (y < 0) continue;
-                        if (y >= Height) break;
-
-                        for (int x = location.X - 3; x <= location.X + 3; x++)
+                        MapObject target = cell.Objects[i];
+                        switch (target.Race)
                         {
-                            if (x < 0) continue;
-                            if (x >= Width) break;
-
-                            cell = GetCell(x, y);
-
-                            if (!cell.Valid || cell.Objects == null) continue;
-
-                            for (int i = 0; i < cell.Objects.Count; i++)
-                            {
-                                MapObject target = cell.Objects[i];
-                                switch (target.Race)
+                            case ObjectType.Monster:
+                            case ObjectType.Player:
+                                //Only targets
+                                if (target.IsAttackTarget(player))
                                 {
-                                    case ObjectType.Monster:
-                                    case ObjectType.Player:
-                                        //Only targets
-                                        if (target.IsAttackTarget(player))
-                                        {
-                                            int chance = Envir.Random.Next(15);
-                                            PoisonType poison;
-                                            if (new int[] { 0, 1, 3 }.Contains(chance)) //3 in 15 chances it'll slow
-                                                poison = PoisonType.Slow;
-                                            else if (new int[] { 3, 4 }.Contains(value)) //2 in 15 chances it'll freeze
-                                                poison = PoisonType.Frozen;
-                                            else if (new int[] { 5, 6, 7, 8, 9 }.Contains(value)) //5 in 15 chances it'll red/green
-                                                poison = (PoisonType)data[4];
-                                            else //5 in 15 chances it'll do nothing
-                                                poison = PoisonType.None;
+                                    int chance = Envir.Random.Next(15);
+                                    PoisonType poison;
+                                    if (new int[] { 0, 1, 3 }.Contains(chance)) //3 in 15 chances it'll slow
+                                        poison = PoisonType.Slow;
+                                    else if (new int[] { 3, 4 }.Contains(value)) //2 in 15 chances it'll freeze
+                                        poison = PoisonType.Frozen;
+                                    else if (new int[] { 5, 6, 7, 8, 9 }.Contains(value)) //5 in 15 chances it'll red/green
+                                        poison = (PoisonType)data[4];
+                                    else //5 in 15 chances it'll do nothing
+                                        poison = PoisonType.None;
 
-                                            int tempValue = 0;
+                                    int tempValue = 0;
 
-                                            if (poison == PoisonType.Green)
-                                            {
-                                                tempValue = value / 15 + magic.Level + 1;
-                                            }
-                                            else
-                                            {
-                                                tempValue = value + (magic.Level + 1) * 2;
-                                            }
+                                    if (poison == PoisonType.Green)
+                                    {
+                                        tempValue = value / 15 + magic.Level + 1;
+                                    }
+                                    else
+                                    {
+                                        tempValue = value + (magic.Level + 1) * 2;
+                                    }
 
-                                            if (poison != PoisonType.None)
-                                            {
-                                                target.ApplyPoison(new Poison { PType = poison, Duration = (2 * (magic.Level + 1)) + (value / 10), TickSpeed = 1000, Value = tempValue, Owner = player }, player, false, false);
-                                            }
-                                            
-                                            if (target.Race == ObjectType.Player)
-                                            {
-                                                PlayerObject tempOb = (PlayerObject)target;
+                                    if (poison != PoisonType.None)
+                                    {
+                                        target.ApplyPoison(new Poison { PType = poison, Duration = (2 * (magic.Level + 1)) + (value / 10), TickSpeed = 1000, Value = tempValue, Owner = player }, player, false, false);
+                                    }
+                                    
+                                    if (target.Race == ObjectType.Player)
+                                    {
+                                        PlayerObject tempOb = (PlayerObject)target;
 
-                                                tempOb.ChangeMP(-tempValue);
-                                            }
+                                        tempOb.ChangeMP(-tempValue);
+                                    }
 
-                                            train = true;
-                                        }
-                                        break;
+                                    target.Attacked(player, player.Stats[Stat.MaxSC] + player.Stats[Stat.MinSC], DefenceType.MAC, true);
+
+                                    train = true;
                                 }
-                            }
-
+                                break;
                         }
-
                     }
 
                     break;

--- a/Server/MirObjects/SpellObject.cs
+++ b/Server/MirObjects/SpellObject.cs
@@ -144,11 +144,11 @@ namespace Server.MirObjects
                         if (!ob.Dead)
                             ob.ApplyPoison(new Poison
                             {
-                                Duration = 15,
+                                Duration = 12,
                                 Owner = Caster,
                                 PType = PoisonType.Green,
-                                TickSpeed = 2000,
-                                Value = Value / 20
+                                TickSpeed = 1000,
+                                Value = (Caster.Stats[Stat.MaxSC] + Caster.Stats[Stat.MinSC]) / 2
                             }, Caster, false, false);
                     }
                     break;


### PR DESCRIPTION
…cial server setting) (#452)

* 增加光照强度(参考官方版本)
Increase the light intensity (refer to the official version)

* 增加光照强度(参考官方版本)
Increase the light intensity (refer to the official version)

* 技能优化(按照官方设定)
1.毒云修改绿毒伤害为道术上线和下限的平均值.
2.瘟疫的目标修改为单体伤害,蓝耗修改为道术上限和下限之和,并对目标造成同样伤害.
3.护身气幕增加防御下限值
4.剑气爆增加攻击下限值,并缩短持续时间
5.幽灵盾/神圣战甲术/无极真气延长持续时间(根据官服经验,非确切官方设定)
6.基本剑术不增加防御
7.攻杀剑术每级增加1点准确,0-3级每级增加5/6/7/8点攻击
8.绝命剑法不增加准确
9.精神力战法不增加攻击力,且1-3级分别增加3/5/8点准确.

Skill modification (according to the official server setting)
1. The skill PoisonCloud modifies the green poison damage to the average value of the MaxSC and MinSC.
2. The skill Plague modified to single damage, and the mana cost is modified to the sum of the MaxSC and MinSC, and it causes the same damage to the target.
3. The skill ProtectionField increases the MinAC.
4. The skill Rage increases the MinDC and shortens the duration.
5. The skill SoulShield/BlessedArmour/UltimateEnhancer extension duration (according to official experience, not the exact official setting).
6. The skill Fencing does not increase defense.
7. The skill Slaying adds 1 point of accuracy per level, and each level of 0-3 increases 5/6/7/8 points of DC.
8. The skill FatalSword does not increase accuracy.
9. The skill SpiritSword do not increase the DC, and the accuracy of 1-3 levels are increased by 3/5/8 points.

Co-authored-by: cjlaaa <cjlaaa@gmai.com>